### PR TITLE
ICAO Airline Code Extraction

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -89,31 +89,3 @@ jobs:
           name: build-windows
           path: |
             build/*.xpl
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [build-linux-macos, build-windows]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: setup crc32 tool
-        shell: bash
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y libarchive-zip-perl
-            TAG=${GITHUB_REF##*/}
-            if [ -n "$TAG" ]; then
-              echo "VERSION=$TAG" > version.mak
-            fi
-
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: ./download
-
-      - name: List artifacts
-        shell: bash
-        run: |
-            pwd
-            ls -lR ./download

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -1,0 +1,119 @@
+name: Test Build
+
+# if the tag contains -test- the build is pushed into the build-test branch
+# so skunkcrafts does not see it
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-linux-macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # use oldest possible ubuntu version in order to avoid compatibility errors with libc
+        os: [ubuntu-22.04, macos-14]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get XPlane SDK + xplib
+        shell: bash
+        run: |
+            SDK_VERSION=411
+            curl -L "https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sdk_zip_files/XPSDK${SDK_VERSION}.zip" -o "XPSDK${SDK_VERSION}.zip"
+            unzip XPSDK${SDK_VERSION}.zip
+            mv SDK ../
+            git clone https://github.com/hotbso/xplib.git ../xplib
+
+      - name: Build Executable
+        shell: bash
+        env:
+          OS: ${{ matrix.os }}
+        run: |
+          TAG=${GITHUB_REF##*/}
+          if [ ! -z "$TAG" ]; then
+            echo "VERSION=$TAG" > version.mak
+          fi
+
+          if [[ $OS == "macos-"* ]]; then
+            make -f Makefile.mac64
+          else
+            sudo apt-get -y install libcurl4-openssl-dev
+            make -f Makefile.lin64
+          fi
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.os }}
+          path: |
+            build/*.xpl
+
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            make
+            git
+
+      - uses: actions/checkout@v3
+
+      - name: Get XPlane SDK + xplib
+        shell: bash
+        run: |
+            SDK_VERSION=411
+            curl -L "https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sdk_zip_files/XPSDK${SDK_VERSION}.zip" -o "XPSDK${SDK_VERSION}.zip"
+            unzip XPSDK${SDK_VERSION}.zip
+            mv SDK ../
+            git clone https://github.com/hotbso/xplib.git ../xplib
+
+      - name: Build Windows binaries
+        shell: msys2 {0}
+        run: |
+            TAG=${GITHUB_REF##*/}
+            if [ ! -z "$TAG" ]; then
+              echo "VERSION=$TAG" > version.mak
+            fi
+            make -f Makefile.mgw64
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-windows
+          path: |
+            build/*.xpl
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build-linux-macos, build-windows]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup crc32 tool
+        shell: bash
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y libarchive-zip-perl
+            TAG=${GITHUB_REF##*/}
+            if [ -n "$TAG" ]; then
+              echo "VERSION=$TAG" > version.mak
+            fi
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./download
+
+      - name: List artifacts
+        shell: bash
+        run: |
+            pwd
+            ls -lR ./download

--- a/ofp_get_parse.cpp
+++ b/ofp_get_parse.cpp
@@ -198,11 +198,11 @@ OfpGetParse(const std::string& pilot_id, std::unique_ptr<OfpInfo>& ofp_info)
     }
 
     if (POSITION("atc")) {
-        EXTRACT("callsign", icao_airline);
+        EXTRACT("callsign", act_callsign);
     }
 
-    std::string callsign = ofp_info->icao_airline;
-    ofp_info->icao_airline = callsign.substr(0, 3);
+    std::string callsign = ofp_info->atc_callsign;
+    ofp_info->atc_callsign = callsign.substr(0, 3);
 
     ofp_info->stale = false;
     ofp_info->seqno = ++seqno;

--- a/ofp_get_parse.cpp
+++ b/ofp_get_parse.cpp
@@ -201,8 +201,8 @@ OfpGetParse(const std::string& pilot_id, std::unique_ptr<OfpInfo>& ofp_info)
         EXTRACT("callsign" icao_airline)
     }
 
-    std::string callsign = ofp_info->icao_airline
-    ofp_info->icao_airline = callsign.substr(0, 3)
+    std::string callsign = ofp_info->icao_airline;
+    ofp_info->icao_airline = callsign.substr(0, 3);
 
     ofp_info->stale = false;
     ofp_info->seqno = ++seqno;

--- a/ofp_get_parse.cpp
+++ b/ofp_get_parse.cpp
@@ -198,7 +198,7 @@ OfpGetParse(const std::string& pilot_id, std::unique_ptr<OfpInfo>& ofp_info)
     }
 
     if (POSITION("atc")) {
-        EXTRACT("callsign" icao_airline)
+        EXTRACT("callsign", icao_airline)
     }
 
     std::string callsign = ofp_info->icao_airline;

--- a/ofp_get_parse.cpp
+++ b/ofp_get_parse.cpp
@@ -198,7 +198,7 @@ OfpGetParse(const std::string& pilot_id, std::unique_ptr<OfpInfo>& ofp_info)
     }
 
     if (POSITION("atc")) {
-        EXTRACT("callsign", icao_airline)
+        EXTRACT("callsign", icao_airline);
     }
 
     std::string callsign = ofp_info->icao_airline;

--- a/ofp_get_parse.cpp
+++ b/ofp_get_parse.cpp
@@ -35,6 +35,7 @@ OfpInfo::Dump() const
     if (status == "Success") {
 #define L(field) LogMsg(#field ": %s", field.c_str())
         L(units);
+        L(iata_airline);
         L(icao_airline);
         L(flight_number);
         L(aircraft_icao);
@@ -164,7 +165,7 @@ OfpGetParse(const std::string& pilot_id, std::unique_ptr<OfpInfo>& ofp_info)
      }
 
     if (POSITION("general")) {
-        EXTRACT("icao_airline", icao_airline);
+        EXTRACT("icao_airline", iata_airline);
         EXTRACT("flight_number", flight_number);
         EXTRACT("costindex", ci);
         EXTRACT("initial_altitude", altitude);
@@ -195,6 +196,13 @@ OfpGetParse(const std::string& pilot_id, std::unique_ptr<OfpInfo>& ofp_info)
         EXTRACT("est_on", est_on);
         EXTRACT("est_in", est_in);
     }
+
+    if (POSITION("atc")) {
+        EXTRACT("callsign" icao_airline)
+    }
+
+    std::string callsign = ofp_info->icao_airline
+    ofp_info->icao_airline = callsign.substr(0, 3)
 
     ofp_info->stale = false;
     ofp_info->seqno = ++seqno;

--- a/sbh.cpp
+++ b/sbh.cpp
@@ -213,7 +213,7 @@ OfpCheckAsyncDownload()
         char line[200];
         snprintf(line, sizeof(line),
                  "%s%s %s / OFP generated at %4d-%02d-%02d %02d:%02d:%02d UTC",
-                 ofp_info->icao_airline.c_str(), ofp_info->flight_number.c_str(), ofp_info->aircraft_icao.c_str(),
+                 ofp_info->iata_airline.c_str(), ofp_info->flight_number.c_str(), ofp_info->aircraft_icao.c_str(),
                  tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
                  tm.tm_hour, tm.tm_min, tm.tm_sec);
 
@@ -721,6 +721,7 @@ XPluginStart(char *out_name, char *out_sig, char *out_desc)
     // XPLMStart must succeed beyond this point
     OFP_DATA_DREF(units);
     OFP_DATA_DREF(status);
+    OFP_DATA_DREF(iata_airline);
     OFP_DATA_DREF(icao_airline);
     OFP_DATA_DREF(flight_number);
     OFP_DATA_DREF(aircraft_icao);

--- a/sbh.cpp
+++ b/sbh.cpp
@@ -213,7 +213,7 @@ OfpCheckAsyncDownload()
         char line[200];
         snprintf(line, sizeof(line),
                  "%s%s %s / OFP generated at %4d-%02d-%02d %02d:%02d:%02d UTC",
-                 ofp_info->iata_airline.c_str(), ofp_info->flight_number.c_str(), ofp_info->aircraft_icao.c_str(),
+                 ofp_info->icao_airline.c_str(), ofp_info->flight_number.c_str(), ofp_info->aircraft_icao.c_str(),
                  tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
                  tm.tm_hour, tm.tm_min, tm.tm_sec);
 
@@ -721,8 +721,8 @@ XPluginStart(char *out_name, char *out_sig, char *out_desc)
     // XPLMStart must succeed beyond this point
     OFP_DATA_DREF(units);
     OFP_DATA_DREF(status);
-    OFP_DATA_DREF(iata_airline);
     OFP_DATA_DREF(icao_airline);
+    OFP_DATA_DREF(atc_callsign);
     OFP_DATA_DREF(flight_number);
     OFP_DATA_DREF(aircraft_icao);
     OFP_DATA_DREF(max_passengers);

--- a/sbh.h
+++ b/sbh.h
@@ -33,8 +33,8 @@ struct OfpInfo
     int seqno{0};       // incremented after each successfull fetch
     F(units);
     F(status);
-    F(iata_airline);
     F(icao_airline);
+    F(atc_callsign);
     F(flight_number);
     F(aircraft_icao);
     F(max_passengers);

--- a/sbh.h
+++ b/sbh.h
@@ -33,6 +33,7 @@ struct OfpInfo
     int seqno{0};       // incremented after each successfull fetch
     F(units);
     F(status);
+    F(iata_airline);
     F(icao_airline);
     F(flight_number);
     F(aircraft_icao);


### PR DESCRIPTION
In previous versions of simbrief hub, the ICAO airline tag was pointing to the IATA airline code. The changes in this pull request change that, while keeping the previous IATA tag

Files Changed/Added : 
1. ofp_get_parse.cpp : Added the ICAO tag obtained from the ATC callsign
2. sbh.h : Added ICAO airline field to the struct
3. sbh.cpp : Added DATAREF pointing to the new ICAO airline, while keeping the previous tag inside sbh/iata_airline. Wherever icao_airline was reference, that has been changed to iata_airline
4. buildtest.yml : Added a workflow for creating the binaries required for XP for local testing.